### PR TITLE
Proposta para pegar ID do item

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -90,6 +90,10 @@ function principal() {
 principal();
 
 function edicaoAtividade() {
+ 
+    function pegaId(item) {
+        return item.getElementsByTagName("span")[0].id
+    }
 
     const toggleModal = () => {
         modalEdicao.classList.toggle("hide");
@@ -99,6 +103,7 @@ function edicaoAtividade() {
     const itemLista = document.querySelectorAll(".secao__formulario__lista__item");       
     itemLista.forEach((item) => {
         item.addEventListener("click", () => {  
+            pegaId(item);
             toggleModal();
         });
     });


### PR DESCRIPTION
# Changelog 📝 

* Adicionei uma função chamada `pegaId`, a qual recebe como parâmetro o item da lista e retorna o id dele (que você configurou como o próprio id da API). Tal ação **pode** resolver o problema de não conseguir acessar o id ao abrir o modal.